### PR TITLE
Add `--keep-order` to maintain input order

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Similar interface to [GNU Parallel](https://www.gnu.org/software/parallel/parall
 * Run commands from [stdin](https://github.com/aaronriekenberg/rust-parallel/wiki/Manual#commands-from-stdin), [input files](https://github.com/aaronriekenberg/rust-parallel/wiki/Manual#reading-multiple-inputs), or [`:::` arguments](https://github.com/aaronriekenberg/rust-parallel/wiki/Manual#commands-from-arguments)
 * Automatic parallelism to all cpus, or [configure manually](https://github.com/aaronriekenberg/rust-parallel/wiki/Manual#parallelism)
 * Transform inputs with [variables](https://github.com/aaronriekenberg/rust-parallel/wiki/Manual#automatic-variables) or [regular expressions](https://github.com/aaronriekenberg/rust-parallel/wiki/Manual#regular-expression)
-* Prevent [output interleaving](https://github.com/aaronriekenberg/rust-parallel/wiki/Output-Interleaving)
+* Prevent [output interleaving](https://github.com/aaronriekenberg/rust-parallel/wiki/Output-Interleaving) and maintain input order with `-k`/`--keep-order`
 * Shell mode to run [bash functions](https://github.com/aaronriekenberg/rust-parallel/wiki/Manual#bash-function) and [commands](https://github.com/aaronriekenberg/rust-parallel/wiki/Manual#shell-commands)
 * [TUI progress bar](https://github.com/aaronriekenberg/rust-parallel/wiki/Manual#progress-bar) using [indicatif](https://github.com/console-rs/indicatif)
 * [Path cache](https://github.com/aaronriekenberg/rust-parallel/wiki/Manual#path-cache)
@@ -54,7 +54,7 @@ brew install rust-parallel
 
 1. [Install Rust](https://www.rust-lang.org/learn/get-started)
 2. Install the latest version of this app from [crates.io](https://crates.io/crates/rust-parallel):
-   
+
     ```
     $ cargo install rust-parallel   
     ```

--- a/scripts/generate_manual.sh
+++ b/scripts/generate_manual.sh
@@ -16,6 +16,7 @@ echo '
 1. [Command and initial arguments on command line](#command-and-initial-arguments-on-command-line)
 1. [Reading multiple inputs](#reading-multiple-inputs)
 1. [Parallelism](#parallelism)
+1. [Keep Output Order](#keep-output-order)
 1. [Dry run](#dry-run)
 1. [Debug logging](#debug-logging)
 1. [Error handling](#error-handling)
@@ -155,6 +156,25 @@ $RUST_PARALLEL -j5 echo ::: hi there how are you
 echo '
 $ rust-parallel -j1 echo ::: hi there how are you'
 $RUST_PARALLEL -j1 echo ::: hi there how are you
+
+echo '```'
+
+echo '## Keep Output Order
+
+By default, command outputs are displayed as soon as each command completes, which may not be in the same order as the input.
+
+Use option `-k`/`--keep-order` to ensure outputs are displayed in the same order as the input.
+
+With `-k` all outputs will be displayed in the same order as the input, regardless of when commands complete.
+'
+
+echo '```
+$ rust-parallel -k echo ::: hi there how are you'
+$RUST_PARALLEL -k echo ::: hi there how are you
+
+echo '
+$ rust-parallel -j1 -k echo ::: hi there how are you'
+$RUST_PARALLEL -j1 -k echo ::: hi there how are you
 
 echo '```'
 

--- a/src/command_line_args.rs
+++ b/src/command_line_args.rs
@@ -77,6 +77,10 @@ pub struct CommandLineArgs {
     #[arg(long)]
     pub no_run_if_empty: bool,
 
+    /// Keep output in the same order as input.
+    #[arg(short, long)]
+    pub keep_order: bool,
+
     /// Path to shell to use for shell mode
     #[arg(long, default_value = Self::default_shell())]
     pub shell_path: String,

--- a/src/output.rs
+++ b/src/output.rs
@@ -66,7 +66,7 @@ impl OutputWriter {
             command_line_args.channel_capacity,
         );
 
-        let output_task_join_handle = tokio::spawn(task::OutputTask::new(receiver).run());
+        let output_task_join_handle = tokio::spawn(task::OutputTask::new(receiver, command_line_args.keep_order).run());
 
         Self {
             sender,

--- a/src/output/task.rs
+++ b/src/output/task.rs
@@ -2,15 +2,18 @@ use tokio::{io::AsyncWrite, sync::mpsc::Receiver};
 
 use tracing::{debug, error, instrument, trace};
 
+use std::collections::BTreeMap;
+
 use super::OutputMessage;
 
 pub struct OutputTask {
     receiver: Receiver<OutputMessage>,
+    keep_order: bool,
 }
 
 impl OutputTask {
-    pub fn new(receiver: Receiver<OutputMessage>) -> Self {
-        Self { receiver }
+    pub fn new(receiver: Receiver<OutputMessage>, keep_order: bool) -> Self {
+        Self { receiver, keep_order }
     }
 
     #[instrument(skip_all, name = "OutputTask::run", level = "debug")]
@@ -22,17 +25,16 @@ impl OutputTask {
             trace!("copy result = {:?}", result);
         }
 
-        let mut stdout = tokio::io::stdout();
-        let mut stderr = tokio::io::stderr();
-
-        let mut receiver = self.receiver;
-
-        while let Some(output_message) = receiver.recv().await {
+        async fn process_output_message(
+            output_message: OutputMessage,
+            stdout: &mut (impl AsyncWrite + Unpin),
+            stderr: &mut (impl AsyncWrite + Unpin),
+        ) {
             if !output_message.stdout.is_empty() {
-                copy(&output_message.stdout, &mut stdout).await;
+                copy(&output_message.stdout, stdout).await;
             }
             if !output_message.stderr.is_empty() {
-                copy(&output_message.stderr, &mut stderr).await;
+                copy(&output_message.stderr, stderr).await;
             }
             if !output_message.exit_status.success() {
                 error!(
@@ -41,6 +43,40 @@ impl OutputTask {
                     output_message.input_line_number,
                     output_message.exit_status.code().unwrap_or_default(),
                 );
+            }
+        }
+
+        let mut stdout = tokio::io::stdout();
+        let mut stderr = tokio::io::stderr();
+
+        let mut receiver = self.receiver;
+
+        if self.keep_order {
+            // When keep-order is enabled, buffer outputs and process them in order
+            let mut buffered_outputs: BTreeMap<usize, OutputMessage> = BTreeMap::new();
+            let mut next_line_number = 0;
+
+            while let Some(output_message) = receiver.recv().await {
+                let line_number = output_message.input_line_number.line_number;
+
+                // Store the output message in the buffer
+                buffered_outputs.insert(line_number, output_message);
+
+                // Process any buffered outputs that are ready (in order)
+                while let Some(output_message) = buffered_outputs.remove(&next_line_number) {
+                    process_output_message(output_message, &mut stdout, &mut stderr).await;
+                    next_line_number += 1;
+                }
+            }
+
+            // Process any remaining buffered outputs
+            for (_, output_message) in buffered_outputs.into_iter() {
+                process_output_message(output_message, &mut stdout, &mut stderr).await;
+            }
+        } else {
+            // When keep-order is disabled, process outputs as they arrive (original behavior)
+            while let Some(output_message) = receiver.recv().await {
+                process_output_message(output_message, &mut stdout, &mut stderr).await;
             }
         }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -58,6 +58,45 @@ fn runs_echo_commands_from_args_j1() {
 }
 
 #[test]
+fn runs_echo_commands_from_args_keep_order() {
+    rust_parallel()
+        .arg("-k")
+        .arg("echo")
+        .arg(":::")
+        .arg("A")
+        .arg("B")
+        .arg("C")
+        .assert()
+        .success()
+        .stdout(
+            (predicate::str::contains("\n").count(3))
+                .and(predicate::str::contains("A\n").count(1))
+                .and(predicate::str::contains("B\n").count(1))
+                .and(predicate::str::contains("C\n").count(1)),
+        )
+        .stderr(predicate::str::is_empty());
+}
+
+#[test]
+fn test_keep_order_with_sleep() {
+    // This test uses sleep commands with different durations
+    // Without -k, the output would be in the order of completion (C, B, A)
+    // With -k, the output should be in the order of input (A, B, C)
+    rust_parallel()
+        .arg("-k")
+        .arg("-s")
+        .arg(r#"sleep {1}; echo {1}"#)
+        .arg(":::")
+        .arg("0.3")
+        .arg("0.2")
+        .arg("0.1")
+        .assert()
+        .success()
+        .stdout(predicate::eq("0.3\n0.2\n0.1\n"))
+        .stderr(predicate::str::is_empty());
+}
+
+#[test]
 fn runs_echo_commands_dry_run() {
     rust_parallel()
         .arg("-s")


### PR DESCRIPTION
To address #35 
```
$ rust-parallel -k -s 'sleep {1} && echo {1}' ::: 3 2 1
3
2
1
```