### PR TITLE
Fix streaming output

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -110,14 +110,14 @@ impl CommandService {
         let context = Arc::new(CommandRunContext {
             child_process_factory: ChildProcessFactory::new(command_line_args),
             command_metrics: CommandMetrics::default(),
-            progress,
+            progress: Arc::clone(&progress),
         });
         Self {
             command_line_args,
             command_path_cache: CommandPathCache::new(command_line_args),
             command_semaphore: Arc::new(Semaphore::new(command_line_args.jobs)),
             context,
-            output_writer: OutputWriter::new(command_line_args),
+            output_writer: OutputWriter::new(command_line_args, progress),
         }
     }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -13,7 +13,9 @@ use std::process::{ExitStatus, Output};
 
 use crate::{
     command_line_args::CommandLineArgs, common::OwnedCommandAndArgs, input::InputLineNumber,
+    progress::Progress,
 };
+use std::sync::Arc;
 
 #[derive(Debug)]
 struct OutputMessage {
@@ -59,7 +61,7 @@ pub struct OutputWriter {
 }
 
 impl OutputWriter {
-    pub fn new(command_line_args: &CommandLineArgs) -> Self {
+    pub fn new(command_line_args: &CommandLineArgs, progress: Arc<Progress>) -> Self {
         let (sender, receiver) = channel(command_line_args.channel_capacity);
         debug!(
             "created output channel with capacity {}",
@@ -67,7 +69,7 @@ impl OutputWriter {
         );
 
         let output_task_join_handle =
-            tokio::spawn(task::OutputTask::new(receiver, command_line_args.keep_order).run());
+            tokio::spawn(task::OutputTask::new(receiver, command_line_args.keep_order, progress).run());
 
         Self {
             sender,

--- a/src/output/task.rs
+++ b/src/output/task.rs
@@ -57,7 +57,7 @@ impl OutputTask {
         if self.keep_order {
             // When keep-order is enabled, buffer outputs and process them in order
             let mut buffered_outputs: BTreeMap<usize, OutputMessage> = BTreeMap::new();
-            let mut next_line_number = 0;
+            let mut next_line_number = 1;
 
             while let Some(output_message) = receiver.recv().await {
                 let line_number = output_message.input_line_number.line_number;

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -49,4 +49,24 @@ impl Progress {
             progress_bar.finish();
         }
     }
+
+    pub fn println(&self, message: impl AsRef<str>) {
+        if let Some(progress_bar) = &self.progress_bar {
+            progress_bar.suspend(|| {
+                println!("{}", message.as_ref());
+            });
+        } else {
+            println!("{}", message.as_ref());
+        }
+    }
+
+    pub fn eprintln(&self, message: impl AsRef<str>) {
+        if let Some(progress_bar) = &self.progress_bar {
+            progress_bar.suspend(|| {
+                eprintln!("{}", message.as_ref());
+            });
+        } else {
+            eprintln!("{}", message.as_ref());
+        }
+    }
 }


### PR DESCRIPTION
The last PR #36  has two issues.

1. The output will be blocked until it gets all results from all subprocesses. This has been addressed by using 1 as the start number in output mapping.
2. The output will break the progress bar if enabled. This requires introducing a reference to the progress bar and writing the output through its provided method. [`progressbar.suspend`](https://docs.rs/indicatif/0.17.11/indicatif/struct.ProgressBar.html#method.suspend).